### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build


### DIFF
--- a/ehcache-core/pom.xml
+++ b/ehcache-core/pom.xml
@@ -558,7 +558,7 @@
     <repositories>
         <repository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -569,7 +569,7 @@
 
         <repository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -581,7 +581,7 @@
         <!--For Hibernate. Test only -->
         <repository>
             <id>jboss-releases</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -593,7 +593,7 @@
         <!--For xsom. Test only -->
         <repository>
             <id>Java.net Maven 2</id>
-            <url>http://download.java.net/maven/2</url>
+            <url>https://download.java.net/maven/2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -606,7 +606,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -616,7 +616,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/ehcache/pom.xml
+++ b/ehcache/pom.xml
@@ -408,23 +408,23 @@
     <repositories>
         <repository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
         </repository>
 
         <repository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
         </pluginRepository>
         <pluginRepository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -499,13 +499,13 @@
     <repository>
       <id>terracotta-snapshots</id>
       <url>
-        http://www.terracotta.org/download/reflector/snapshots
+        https://www.terracotta.org/download/reflector/snapshots
       </url>
     </repository>
     <repository>
       <id>terracotta-releases</id>
       <url>
-        http://www.terracotta.org/download/reflector/releases
+        https://www.terracotta.org/download/reflector/releases
       </url>
     </repository>
   </repositories>
@@ -513,13 +513,13 @@
     <pluginRepository>
       <id>terracotta-snapshots</id>
       <url>
-        http://www.terracotta.org/download/reflector/snapshots
+        https://www.terracotta.org/download/reflector/snapshots
       </url>
     </pluginRepository>
     <pluginRepository>
       <id>terracotta-releases</id>
       <url>
-        http://www.terracotta.org/download/reflector/releases
+        https://www.terracotta.org/download/reflector/releases
       </url>
     </pluginRepository>
   </pluginRepositories>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -53,21 +53,21 @@
     <repositories>
         <repository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
         </repository>
         <repository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
         </pluginRepository>
         <pluginRepository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -20,7 +20,7 @@
     <repositories>
         <repository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -30,7 +30,7 @@
         </repository>
         <repository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -43,7 +43,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>terracotta-snapshots</id>
-            <url>http://www.terracotta.org/download/reflector/snapshots</url>
+            <url>https://www.terracotta.org/download/reflector/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -53,7 +53,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>terracotta-releases</id>
-            <url>http://www.terracotta.org/download/reflector/releases</url>
+            <url>https://www.terracotta.org/download/reflector/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://infosecwriteups.com/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb)

---

This is a security fix for a high severity vulnerability in your [Apache Maven](https://maven.apache.org/) `pom.xml` file(s).

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS.
This leaves your build vulnerable to allowing a [Man in the Middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (MITM) attackers to execute arbitrary code on your or your computer or CI/CD system.

This vulnerability has a CVSS v3.0 Base Score of [8.1/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H).

[POC code](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/) has existed since 2014 to maliciously compromise a JAR file in-flight.
MITM attacks against HTTP are [increasingly common](https://security.stackexchange.com/a/12050), for example [Comcast is known to have done it to their own users](https://thenextweb.com/news/comcast-continues-to-inject-its-own-code-into-websites-you-visit).

## Resources

- [Want to take over the Java ecosystem? All you need is a MITM!](https://infosecwriteups.com/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb)
- [Update: Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/bugbountywriteup/update-want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-d069d253fe23?source=friends_link&sk=8c8e52a7d57b98d0b7e541665688b454)
- [CVE-2021-26291](https://nvd.nist.gov/vuln/detail/CVE-2021-26291)
## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly handcrafted :heart: to bring this security fix to your repository.

The source code that generated this PR can be found here: [UseHttpsForRepositories]()

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-maven-non-https-url/).


You can automatically detect future vulnerabilities, like this one, by enabling the free (for open-source) [CodeQL: GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher for the Open Source Security Foundation.
## Opting Out

If you'd like to opt out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)

## Sponsorship & Support

This work was originally sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This work was later sponsored by [Open Source Security Foundation (OpenSSF)](https://openssf.org/): Project [Alpha-Omega](https://openssf.org/community/alpha-omega/).
Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code – and get them fixed – to improve global software supply chain security.

This PR was generated with [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.
## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/8


Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/IfHkrYfxx?organizationId=QWxsIEdpdEh1Yg%3D%3D